### PR TITLE
fix: 修复 Makefile 缺少目录创建导致编译失败

### DIFF
--- a/luci-app-simple2fa/Makefile
+++ b/luci-app-simple2fa/Makefile
@@ -15,6 +15,8 @@ define Package/luci-app-simple2fa/install
 	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/view/simple2fa
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DIR) $(1)/usr/share/luci-app-simple2fa
 	
 	$(INSTALL_DATA) ./luasrc/controller/simple2fa.lua $(1)/usr/lib/lua/luci/controller/
 	$(INSTALL_DATA) ./luasrc/model/cbi/simple2fa/*.lua $(1)/usr/lib/lua/luci/model/cbi/simple2fa/


### PR DESCRIPTION
## 问题

Makefile 中缺少目录创建导致编译失败：
```
install: cannot create regular file '.../etc/uci-defaults/': Not a directory
```

## 修复

添加缺失的 INSTALL_DIR：
- $(1)/etc/uci-defaults
- $(1)/usr/share/luci-app-simple2fa